### PR TITLE
Add schema.org linked data for breadcrumbs

### DIFF
--- a/pages/courses.js
+++ b/pages/courses.js
@@ -9,7 +9,8 @@ export default function Courses({
 }) {
   const breadcrumbs = [
     {
-      label: 'Courses'
+      label: 'Courses',
+      url: '/courses',
     }
   ]
 

--- a/pages/firetips.js
+++ b/pages/firetips.js
@@ -10,6 +10,7 @@ export default function Firetips({
   const breadcrumbs = [
     {
       label: 'Fire tips',
+      url: '/firetips'
     },
   ]
 

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -9,7 +9,8 @@ export default function Projects({
 }) {
   const breadcrumbs = [
     {
-      label: 'Projects'
+      label: 'Projects',
+      url: '/projects',
     }
   ]
 

--- a/pages/writing.js
+++ b/pages/writing.js
@@ -10,6 +10,7 @@ export default function Writing({
   const breadcrumbs = [
     {
       label: 'Writing',
+      url: '/writing',
     },
   ]
 

--- a/src/components/breadcrumbs.js
+++ b/src/components/breadcrumbs.js
@@ -1,37 +1,57 @@
 import { Fragment } from 'react'
 
+import config from '@/config'
+import LinkedData from '@/components/linked-data'
+
 export default function Breadcrumbs({
   breadcrumbs,
 }) {
   return (
-    <nav className="font-medium text-sm">
-      {[
-        {
-          label: 'Home',
-          url: '/'
-        },
-        ...breadcrumbs
-      ].map(({
-        label,
-        url
-      }) => url ? (
-        <Fragment key={label}>
-          <a
-            className="inline-block text-gray-800 dark:text-gray-100"
-            href={url}
-          >
-            {label}
-          </a>
+    <Fragment>
+      <nav className="font-medium text-sm">
+        {[
+          {
+            label: 'Home',
+            url: '/'
+          },
+          ...breadcrumbs
+        ].map(({
+          label,
+          url
+        }, index) => index < breadcrumbs.length ? (
+          <Fragment key={label}>
+            <a
+              className="inline-block text-gray-800 dark:text-gray-100"
+              href={url}
+            >
+              {label}
+            </a>
 
-          <span className="mx-1 text-gray-500 dark:text-gray-400">
-            &raquo;
+            <span className="mx-1 text-gray-500 dark:text-gray-400">
+              &raquo;
+            </span>
+          </Fragment>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400" key={label}>
+            {label}
           </span>
-        </Fragment>
-      ) : (
-        <span className="text-gray-500 dark:text-gray-400" key={label}>
-          {label}
-        </span>
-      ))}
-    </nav>
+        ))}
+      </nav>
+
+      <LinkedData
+        schema={{
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          itemListElement: breadcrumbs.map((item, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            item: {
+              '@id': `${config.siteUrl}${item.url}`,
+              name: item.label,
+            }
+          }))
+        }}
+      />
+    </Fragment>
   )
 }

--- a/src/components/linked-data.js
+++ b/src/components/linked-data.js
@@ -1,0 +1,10 @@
+export default function LinkedData({
+  schema,
+}) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}

--- a/src/lib/api/articles.js
+++ b/src/lib/api/articles.js
@@ -26,6 +26,7 @@ const transform = async ({
         url: '/writing',
       }, {
         label: frontmatter.title,
+        url: `/${slug}`,
       },
     ],
     ogImage,

--- a/src/lib/api/course-lessons.js
+++ b/src/lib/api/course-lessons.js
@@ -15,6 +15,7 @@ const transform = course => ({
       url: course.permalink,
     }, {
       label: frontmatter.title,
+      url: `/${course.slug}/${slug}`,
     }
   ],
   ogImage: getOgImageForPath(`${course.slug}/${slug}`),

--- a/src/lib/api/courses.js
+++ b/src/lib/api/courses.js
@@ -11,6 +11,7 @@ const transform = ({
       url: '/courses',
     }, {
       label: frontmatter.title,
+      url: `/${slug}`,
     },
   ],
   ogImage: getOgImageForPath(slug),

--- a/src/lib/api/firetips.js
+++ b/src/lib/api/firetips.js
@@ -12,6 +12,7 @@ const transform = async ({
         url: '/firetips',
       }, {
         label: frontmatter.title,
+        url: `/${slug}`,
       },
     ],
     ogImage: getOgImageForPath(slug),

--- a/src/lib/api/pages.js
+++ b/src/lib/api/pages.js
@@ -8,6 +8,7 @@ const transform = ({
   breadcrumbs: [
     {
       label: frontmatter.title,
+      url: `/${slug}`,
     }
   ],
   ogImage: getOgImageForPath(slug),

--- a/src/lib/api/projects.js
+++ b/src/lib/api/projects.js
@@ -11,6 +11,7 @@ const transform = ({
       url: '/projects',
     }, {
       label: frontmatter.title,
+      url: `/${slug}`,
     },
   ],
   hero: `/api/projects/${slug}/hero.png`,


### PR DESCRIPTION
Now that the URLs are no longer directly nested, this might give Google a better idea of how the pages are nested.